### PR TITLE
add granular badgecounts + save to csv instead of a json object

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.7.7",
-    "cheerio": "^1.0.0"
+    "cheerio": "^1.0.0",
+    "json2csv": "6.0.0-alpha.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -96,17 +96,18 @@ async function getPlayerDetail(team, playerUrl) {
     p.offensiveConsistency = parseInt(offensiveConsistency);
 
     // badges
-    let legendaryBadgeCount = cheerio.load(response.data)('.badge-count')[0].children[0].data
+    const badgeRawData = cheerio.load(response.data)('.badge-count')
+    let legendaryBadgeCount = badgeRawData[0].children[0].data
     p.legendaryBadgeCount = parseInt(legendaryBadgeCount)
-    let purpleBadgeCount = cheerio.load(response.data)('.badge-count')[1].children[0].data
+    let purpleBadgeCount = badgeRawData[1].children[0].data
     p.purpleBadgeCount = parseInt(purpleBadgeCount)
-    let goldBadgeCount = cheerio.load(response.data)('.badge-count')[2].children[0].data
+    let goldBadgeCount = badgeRawData[2].children[0].data
     p.goldBadgeCount = parseInt(goldBadgeCount)
-    let silverBadgeCount = cheerio.load(response.data)('.badge-count')[3].children[0].data
+    let silverBadgeCount = badgeRawData[3].children[0].data
     p.silverBadgeCount = parseInt(silverBadgeCount)
-    let bronzeBadgeCount = cheerio.load(response.data)('.badge-count')[4].children[0].data
+    let bronzeBadgeCount = badgeRawData[4].children[0].data
     p.bronzeBadgeCount = parseInt(bronzeBadgeCount)
-    let badgeCount = cheerio.load(response.data)('.badge-count')[5].children[0].data
+    let badgeCount = badgeRawData[5].children[0].data
     p.badgeCount = parseInt(badgeCount)
 
     const rawOutsideScoringCount = cheerio.load(response.data)('#pills-outscoring-tab').text();

--- a/src/player.js
+++ b/src/player.js
@@ -4,9 +4,24 @@
 export var player = function () {
   // general
   this.name = "";
+  this.height = "";
+  this.position = "";
+  this.legendaryBadgeCount = 0;
+  this.purpleBadgeCount = 0;
+  this.goldBadgeCount = 0;
+  this.silverBadgeCount = 0;
+  this.bronzeBadgeCount = 0;
+  this.outsideScoringBadgeCount = 0;
+  this.insideScoringBadgeCount = 0;
+  this.generalOffenseBadgeCount = 0;
+  this.playmakingBadgeCount = 0;
+  this.defensiveBadgeCount = 0;
+  this.reboundingBadgeCount = 0;
+  this.allAroundBadgeCount = 0;
+  
+  this.badgeCount = 0;
   this.team = "";
   this.overallAttribute = 0;
-
   // outside scoring
   this.closeShot = 0;
   this.midRangeShot = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@streamparser/json@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@streamparser/json/-/json-0.0.6.tgz#6d5853197f52d765d99a23767c951c03676a0e27"
+  integrity sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -56,6 +61,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 css-select@^5.1.0:
   version "5.1.0"
@@ -151,6 +161,20 @@ iconv-lite@0.6.3, iconv-lite@^0.6.3:
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
+
+json2csv@6.0.0-alpha.2:
+  version "6.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-6.0.0-alpha.2.tgz#ef859e8883a5db1077d784e302a79003c13c212f"
+  integrity sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==
+  dependencies:
+    "@streamparser/json" "^0.0.6"
+    commander "^6.2.0"
+    lodash.get "^4.4.2"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 mime-db@1.52.0:
   version "1.52.0"


### PR DESCRIPTION
big fan of this repo! 

added some support to add the granular badge counts here:

<img width="413" alt="Screenshot 2024-11-17 at 7 57 08 PM" src="https://github.com/user-attachments/assets/67bc5a8b-37ad-475e-abe6-b12d020dbd71">
<img width="1042" alt="Screenshot 2024-11-17 at 7 57 01 PM" src="https://github.com/user-attachments/assets/3aaba2d4-dc47-4310-b123-c798d1c43093">

take what you need
